### PR TITLE
 [MINOR] Update README footer imagelink

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,4 +98,4 @@ landsat_download(download_url = downurl$product_dload_url, dest_file = getwd())
 
 Cheers to open data :blush:
 
-<img src="http://i65.tinypic.com/9h4ajs.png" align="centre" />
+<img src="https://user-images.githubusercontent.com/408863/66741678-a78ab780-ee93-11e9-8d90-b274af222339.png" align="centre" />


### PR DESCRIPTION
- Use footer image on Github itself instead of a third party service
- Got the original image from Wayback Archive (https://web.archive.org/web/*/https://github.com/atlanhq/camelot)